### PR TITLE
Fix Requirements for django-jinja-knockout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ Selenium tests
 
 Inside project virtual environment install selenium 3.4 or newer::
 
-    pip3 install -r dev-requirements.txt
+    pip3 install -r ./requirements/dev.txt
 
 To use `Bootstrap 3`_ version::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 django-allauth
-git+https://github.com/Dmitri-Sintsov/django-jinja-knockout.git
+# For the beta Version
+# git+https://github.com/Dmitri-Sintsov/django-jinja-knockout.git
 git+https://github.com/Dmitri-Sintsov/django-deno.git
-# django-jinja-knockout
+django-jinja-knockout~=1.1.0
 


### PR DESCRIPTION
The current requirements file pulls 2.0a1 and causes this error https://github.com/Dmitri-Sintsov/djk-sample/issues/4. Changing it to the current stable seems to fix it. 

Also fix the location of dev.txt in the readme. 
